### PR TITLE
Update setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ zip_safe = False
 packages = toponymy
 python_requires = >=3.9
 install_requires =
-    numpy>=1.21
+    numpy==1.24
     pandas>=1.0
     numba>=0.56
     datasets


### PR DESCRIPTION
when numpy>=1.22, it will install numpy above 2.... which will introduce the error "RuntimeError: Numpy is not available"

<img width="1198" alt="image" src="https://github.com/user-attachments/assets/9950dd41-4b5e-47d6-9026-0e004f4508fd" />
